### PR TITLE
Fix industrial cooler losing exhaust ports when map is switched

### DIFF
--- a/RedistHeat/Building/Building_AirNets/Building_DuctComp.cs
+++ b/RedistHeat/Building/Building_AirNets/Building_DuctComp.cs
@@ -208,10 +208,10 @@ namespace RedistHeat
                         //float result = ((diff * room.Temperature) + (avgTemp * force)) / room.CellCount;
                         float result = ((room.CellCount * room.Temperature * adjust) + (avgTemp * force)) / (room.CellCount*adjust+ force);
                         room.Group.Temperature = result;
-                    }
 #if DEBUG
                     Log.Message("RedistHeat: Intake room result temp: " + result);
 #endif
+                    }
                 }
             }
             else

--- a/RedistHeat/Building/Building_TempControl/Building_ExhaustPort.cs
+++ b/RedistHeat/Building/Building_TempControl/Building_ExhaustPort.cs
@@ -74,7 +74,7 @@ namespace RedistHeat
 
         private Building_IndustrialCooler AdjacentCooler()
         {
-            var cooler = Find.VisibleMap.thingGrid.ThingAt< Building_IndustrialCooler >( VecSouth );
+            var cooler = Map.thingGrid.ThingAt< Building_IndustrialCooler >( VecSouth );
             return cooler;
         }
     }

--- a/RedistHeat/Building/Building_TempControl/Building_IndustrialCooler.cs
+++ b/RedistHeat/Building/Building_TempControl/Building_IndustrialCooler.cs
@@ -118,14 +118,13 @@ namespace RedistHeat
             }
         }
 
-        private List< Building_ExhaustPort > GetActiveExhausts()
+        private List<Building_ExhaustPort> GetActiveExhausts()
         {
-            var origin = GenAdj.CellsAdjacentCardinal( this )
-                               .Select( s => Find.VisibleMap.thingGrid.ThingAt< Building_ExhaustPort >( s ) )
-                               .Where( thingAt => thingAt != null )
-                               .ToList();
-
-            return origin.Where( s => s.isAvailable ).ToList();
+            return GenAdj.CellsAdjacentCardinal(this)
+                .Select(s => Map.thingGrid.ThingAt<Building_ExhaustPort>(s))
+                .Where(thingAt => thingAt != null)
+                .Where(s => s.isAvailable)
+                .ToList();
         }
 
         public override string GetInspectString()


### PR DESCRIPTION
This fixes industrial coolers losing their active exhaust ports when the player switches to another map