### PR TITLE
Get layer for duct overlay from CompAir directly

### DIFF
--- a/RedistHeat/Building/Building_AirNets/Building_DuctBase.cs
+++ b/RedistHeat/Building/Building_AirNets/Building_DuctBase.cs
@@ -1,17 +1,8 @@
-﻿using System.Linq;
-using RimWorld;
-using Verse;
+﻿using RimWorld;
 
 namespace RedistHeat
 {
     public class Building_DuctBase : Building_TempControl
     {
-        public void PrintForAirGrid( SectionLayer layer )
-        {
-            foreach (var current in AllComps.Where( s => s is CompAir ).Cast< CompAir >())
-            {
-                current.CompPrintForAirGrid( layer );
-            }
-        }
     }
 }

--- a/RedistHeat/Misc/SectionLayer_AirNetOverlay.cs
+++ b/RedistHeat/Misc/SectionLayer_AirNetOverlay.cs
@@ -21,8 +21,7 @@ namespace RimWorld
 
         protected override void TakePrintFrom( Thing t )
         {
-            var ductBuilding = t as Building_DuctBase;
-            ductBuilding?.PrintForAirGrid( this );
+            t.TryGetComp<CompAir>()?.CompPrintForAirGrid(this);
         }
     }
 }


### PR DESCRIPTION
The duct overlay grabs the layer from AirComp instead of using DuctBase then getting the comp. Allows for third party buildings using AirComp to be rendered with the overlay.