### PR TITLE
Get right air net temp on load and misc fixes

### DIFF
--- a/Defs/ThingDefs/Buildings_TempController.xml
+++ b/Defs/ThingDefs/Buildings_TempController.xml
@@ -307,6 +307,7 @@
         </costList>
         <placeWorkers>
             <li>PlaceWorker_Heater</li>
+            <li>RedistHeat.PlaceWorker_DuctBase</li>
         </placeWorkers>
         <comps>
 			<li Class="RedistHeat.CompAirTraderProperties">

--- a/RedistHeat/AirNet/AirNet.cs
+++ b/RedistHeat/AirNet/AirNet.cs
@@ -69,7 +69,7 @@ namespace RedistHeat
                                 s.parent.def.defName == "RedistHeat_DuctIntake" ||
                                 s.parent.def.defName == "RedistHeat_DuctCooler" );
 
-            if (intake == null || intake.netTemp == 999)
+            if (intake == null || intake.netTemp < Common.AbsoluteZero)
             {
                 NetTemperature =  map.mapTemperature.OutdoorTemp;
             }

--- a/RedistHeat/AirNet/AirNet.cs
+++ b/RedistHeat/AirNet/AirNet.cs
@@ -10,101 +10,103 @@ namespace RedistHeat
     {
         public readonly int debugId;
         private static int debugIdNext;
-        private CompAir root;
+        private readonly CompAir root;
         
         public readonly List< CompAir > nodes = new List< CompAir >();
         public int pushers;
         public int pullers;
-        private int countdown = 0;
+        private int countdown;
 
         private float netTemperature;
 
         public float NetTemperature
         {
-            get { return netTemperature; }
-            set { netTemperature = Mathf.Clamp( value, -270, 2000 ); }
+            get => netTemperature;
+            set => netTemperature = Mathf.Clamp( value, -270, 2000 ); 
         }
 
         public NetLayer Layer { get; }
         public int LayerInt => (int) Layer;
 
-
         public AirNet( IEnumerable< CompAir > newNodes, NetLayer layer, CompAir root, Map map )
         {
+            var intakeRoomTemp = -500f;
+            
+            netTemperature = -500f;
             Layer = layer;
             pushers = 0;
             pullers = 0;
-            var compAirs = newNodes.ToList();
+            
+            this.root = root;
+            debugId = debugIdNext++;
 
-            foreach (var current in compAirs)
+            foreach (var current in newNodes)
             {
                 RegisterNode( current );
                 current.connectedNet = this;
-                /*if (current.GetType() == typeof(CompAirTrader))
+
+                if (netTemperature >= Common.AbsoluteZero) continue;
+                switch (current)
                 {
-                    var units = ((CompAirTrader)current).Props.units;
-                    if (units > 0)
-                    {
-                        pushers += units;
-                    }
-                    else
-                    {
-                        pullers += -units;
-                    }
-                }*/
+                    case CompAirTrader airTrader:
+                        if (airTrader.Props.units > 0)
+                        {
+                            AddPusherOrPuller(airTrader);
+                            var room = airTrader.parent.GetRoom();
+                            if (room != null)
+                            {
+                                intakeRoomTemp = room.Temperature;
+                            }
+                        }
+
+                        if (airTrader.netTemp >= Common.AbsoluteZero)
+                        {
+                            netTemperature = airTrader.netTemp;
+                        }
+                        break;    
+                }
             }
 
-            checked
+            if (netTemperature < Common.AbsoluteZero)
             {
-                debugId = debugIdNext++;
-            }
-            this.root = root;
-
-            var intake =
-                compAirs.Where( s => s.GetType() == typeof(CompAirTrader) )
-                        .Cast< CompAirTrader >()
-                        .ToList()
-                        .Find(
-                            s =>
-                                s.parent.def.defName == "RedistHeat_DuctIntake" ||
-                                s.parent.def.defName == "RedistHeat_DuctCooler" );
-
-            if (intake == null || intake.netTemp < Common.AbsoluteZero)
-            {
-                NetTemperature =  map.mapTemperature.OutdoorTemp;
-            }
-            else
-            {
-                NetTemperature = intake.netTemp;
+                netTemperature = intakeRoomTemp < Common.AbsoluteZero
+                    ? intakeRoomTemp
+                    : map.mapTemperature.OutdoorTemp;
             }
         }
 
+        private void AddPusherOrPuller(CompAirTrader airTrader)
+        {
+            if (airTrader.Props.units > 0)
+            {
+                pullers += airTrader.Props.units;
+            } 
+            else if (airTrader.Props.units < 0)
+            {
+                pushers += airTrader.Props.units;
+            }
+        }
+        
         public void AirNetTick()
         {
+            // TODO use hugs custom ticker instead
+            // https://github.com/UnlimitedHugs/RimworldHugsLib/wiki/Custom-Tick-Scheduling
             if(countdown >= 60)
             {
                 countdown = 0;
                 pullers = 0;
                 pushers = 0;
-                foreach (var current in nodes)
+                
+                foreach (var current in nodes.Select(s => s as CompAirTrader).Where(s => s != null))
                 {
-                    if (current.GetType() == typeof(CompAirTrader))
+                    switch (current.parent)
                     {
-                        if(current.parent.def.defName == "RedistHeat_DuctIntake" || current.parent.def.defName == "RedistHeat_DuctOutlet" || current.parent.def.defName == "RedistHeat_SmartDuctOutlet")
-                        {
-                            if (!((Building_DuctComp)current.parent).isLocked)
-                            {
-                                var units = ((CompAirTrader)current).Props.units;
-                                if (units > 0)
-                                {
-                                    pushers += units;
-                                }
-                                else
-                                {
-                                    pullers += -units;
-                                }
-                            }
-                        }
+                        case Building_DuctComp ductComp:
+                            if (!ductComp.isLocked) AddPusherOrPuller(current);
+                            break;
+                        default:
+                            AddPusherOrPuller(current);
+                            break;
                     }
                 }
 #if DEBUG
@@ -112,7 +114,6 @@ namespace RedistHeat
 #endif
             }
             countdown++;
-
         }
 
         public void RegisterNode( CompAir node )

--- a/RedistHeat/AirNet/AirNet.cs
+++ b/RedistHeat/AirNet/AirNet.cs
@@ -83,7 +83,7 @@ namespace RedistHeat
             } 
             else if (airTrader.Props.units < 0)
             {
-                pushers += airTrader.Props.units;
+                pushers -= airTrader.Props.units;
             }
         }
         

--- a/RedistHeat/Building/Building_AirNets/Building_DuctComp.cs
+++ b/RedistHeat/Building/Building_AirNets/Building_DuctComp.cs
@@ -55,7 +55,7 @@ namespace RedistHeat
             base.SpawnSetup(map, respawningAfterLoad);
             compAir = GetComp< CompAirTrader >();
 
-            Common.WipeExistingPipe( Position );
+            Common.WipeExistingPipe(map, Position);
         }
 
         public override void ExposeData()

--- a/RedistHeat/Building/Building_AirNets/Building_DuctSwitchable.cs
+++ b/RedistHeat/Building/Building_AirNets/Building_DuctSwitchable.cs
@@ -44,7 +44,7 @@ namespace RedistHeat
             base.SpawnSetup(map, respawningAfterLoad);
             compAir = GetComp<CompAirTrader>();
 
-            Common.WipeExistingPipe(Position);
+            Common.WipeExistingPipe(map, Position);
         }
 
         public override void Tick()

--- a/RedistHeat/CompProperties/CompDuctSwitchableProperties.cs
+++ b/RedistHeat/CompProperties/CompDuctSwitchableProperties.cs
@@ -4,10 +4,9 @@ namespace RedistHeat
 {
     public class CompDuctSwitchableProperties : CompProperties
     {
-        public bool connectedToNet = true;
         public CompDuctSwitchableProperties()
         {
-            this.compClass = typeof(CompDuctSwitchable);
+            compClass = typeof(CompDuctSwitchable);
         }
     }
 }

--- a/RedistHeat/Misc/Common.cs
+++ b/RedistHeat/Misc/Common.cs
@@ -25,13 +25,12 @@ namespace RedistHeat
             return ("RedistHeat_" + layer + "ChannelTranslated").Translate();
         }
 
-        public static void WipeExistingPipe( IntVec3 pos)
+        public static void WipeExistingPipe(Map map, IntVec3 pos)
         {
-            var pipe =
-                Find.VisibleMap.thingGrid.ThingsAt( pos ).ToList().Find(
-                    s => s.def.defName == "RedistHeat_DuctPipeLower" || s.def.defName == "RedistHeat_DuctPipeUpper" );
-
-            pipe?.Destroy();
+            foreach (var pipe in map.thingGrid.ThingsAt(pos).Select(s => s as Building_DuctPipe))
+            {
+                pipe?.Destroy();
+            }
         }
     }
 }

--- a/RedistHeat/Misc/Common.cs
+++ b/RedistHeat/Misc/Common.cs
@@ -13,6 +13,8 @@ namespace RedistHeat
 
     public static class Common
     {
+        public const float AbsoluteZero = -273.15f;
+        
         public static int NetLayerCount()
         {
             return Enum.GetValues( typeof(NetLayer) ).Length;

--- a/RedistHeat/ThingComps/CompAirTrader.cs
+++ b/RedistHeat/ThingComps/CompAirTrader.cs
@@ -7,20 +7,14 @@ namespace RedistHeat
     {
         public float netTemp;
 
-        public CompAirTraderProperties Props
-        {
-            get
-            {
-                return (CompAirTraderProperties)this.props;
-            }
-        }
+        public CompAirTraderProperties Props => (CompAirTraderProperties) props;
 
         public override void PostSpawnSetup(bool respawningAfterLoad)
         {
             base.PostSpawnSetup(respawningAfterLoad);
-            if (netTemp == 0f)
+            if (netTemp < Common.AbsoluteZero)
             {
-                netTemp = this.parent.Map.mapTemperature.OutdoorTemp;
+                netTemp = parent.Map.mapTemperature.OutdoorTemp;
             }
         }
 
@@ -73,7 +67,7 @@ namespace RedistHeat
         {
             base.PostExposeData();
 
-            Scribe_Values.Look( ref netTemp, "netTemp", 999 );
+            Scribe_Values.Look( ref netTemp, "netTemp", -500f );
         }
     }
 }


### PR DESCRIPTION
Couple of changes. Each commit is atomic and represents a single feature.  Included:
- Add duct place worker to industrial heater
- Use class names and properties to find intakes & outlets, and duct piping
  - Allows for third party pushers and pullers
  - Prevents weird bugs if def names change
- Get airnet temp from a connected device, then an intake temp, then outdoor temp on load
    - Fixes ducting heating up in freezers and killing crops in the arctic on load
